### PR TITLE
Fix Url pymc-bart on documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We welcome a wide range of contributions, not only code!
 
 ## Reporting issues
 If you encounter any bug or incorrect behaviour while using pymc_bart,
-please report an issue to our [issue tracker](https://github.com/pymc-devs/pymc_bart/issues).
+please report an issue to our [issue tracker](https://github.com/pymc-devs/pymc-bart/issues).
 Please include any supporting information, in particular the version of
 pymc_bart that you are using.
 The issue tracker has several templates available to help in writing the issue

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ pip install git+https://github.com/pymc-devs/pymc-bart.git
 
 ## Contributions
 PyMC-BART is a community project and welcomes contributions.
-Additional information can be found in the [Contributing Readme](https://github.com/pymc-devs/pymc_bart/blob/main/CONTRIBUTING.md)
+Additional information can be found in the [Contributing Readme](https://github.com/pymc-devs/pymc-bart/blob/main/CONTRIBUTING.md)
 
 ## Code of Conduct
 PyMC-BART wishes to maintain a positive community. Additional details
-can be found in the [Code of Conduct](https://github.com/pymc-devs/pymc_bart/blob/main/CODE_OF_CONDUCT.md)
+can be found in the [Code of Conduct](https://github.com/pymc-devs/pymc-bart/blob/main/CODE_OF_CONDUCT.md)
 
 ## Citation
 If you use PyMC-BART and want to cite it please use [![arXiv](https://img.shields.io/badge/arXiv-2206.03619-b31b1b.svg)](https://arxiv.org/abs/2206.03619)


### PR DESCRIPTION
Fix url from pymc-bart to properly link the issue tracker, contributing readme and code of conduct;