### PR TITLE
Refactor to avoid inheritance in BaseNode

### DIFF
--- a/pymc_bart/pgbart.py
+++ b/pymc_bart/pgbart.py
@@ -29,8 +29,7 @@ from pymc.pytensorf import inputvars, join_nonshared_inputs, make_shared_replace
 
 
 from pymc_bart.bart import BARTRV
-from pymc_bart.tree import LeafNode, SplitNode, Tree
-
+from pymc_bart.tree import Tree, Node
 
 _log = logging.getLogger("pymc")
 
@@ -412,7 +411,7 @@ class SampleSplittingVariable:
 
 def compute_prior_probability(alpha):
     """
-    Calculate the probability of the node being a LeafNode (1 - p(being SplitNode)).
+    Calculate the probability of the node being a leaf node (1 - p(being split node)).
 
     Taken from equation 19 in [Rockova2018].
 
@@ -480,17 +479,17 @@ def grow_tree(
                 shape,
             )
 
-            new_node = LeafNode(
+            new_node = Node.new_leaf_node(
                 index=current_node_children[idx],
                 value=node_value,
                 idx_data_points=idx_data_point,
             )
             new_nodes.append(new_node)
 
-        new_split_node = SplitNode(
+        new_split_node = Node.new_split_node(
             index=index_leaf_node,
-            idx_split_variable=selected_predictor,
             split_value=split_value,
+            idx_split_variable=selected_predictor,
         )
 
         # update tree nodes and indexes

--- a/tests/test_bart.py
+++ b/tests/test_bart.py
@@ -8,27 +8,6 @@ from pymc.tests.distributions.util import assert_moment_is_expected
 import pymc_bart as pmb
 
 
-def test_split_node():
-    split_node = pmb.tree.SplitNode(index=5, idx_split_variable=2, split_value=3.0)
-    assert split_node.index == 5
-    assert split_node.idx_split_variable == 2
-    assert split_node.split_value == 3.0
-    assert split_node.depth == 2
-    assert split_node.get_idx_parent_node() == 2
-    assert split_node.get_idx_left_child() == 11
-    assert split_node.get_idx_right_child() == 12
-
-
-def test_leaf_node():
-    leaf_node = pmb.tree.LeafNode(index=5, value=3.14, idx_data_points=[1, 2, 3])
-    assert leaf_node.index == 5
-    assert np.array_equal(leaf_node.idx_data_points, [1, 2, 3])
-    assert leaf_node.value == 3.14
-    assert leaf_node.get_idx_parent_node() == 2
-    assert leaf_node.get_idx_left_child() == 11
-    assert leaf_node.get_idx_right_child() == 12
-
-
 def test_bart_vi():
     X = np.random.normal(0, 1, size=(250, 3))
     Y = np.random.normal(0, 1, size=250)

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from pymc_bart.tree import Node
+
+
+def test_split_node():
+    split_node = Node.new_split_node(index=5, idx_split_variable=2, split_value=3.0)
+    assert split_node.index == 5
+    assert split_node.depth == 2
+    assert split_node.value == 3.0
+    assert split_node.idx_split_variable == 2
+    assert split_node.idx_data_points is None
+    assert split_node.get_idx_parent_node() == 2
+    assert split_node.get_idx_left_child() == 11
+    assert split_node.get_idx_right_child() == 12
+    assert split_node.is_split_node() is True
+    assert split_node.is_leaf_node() is False
+
+
+def test_leaf_node():
+    leaf_node = Node.new_leaf_node(index=5, value=3.14, idx_data_points=[1, 2, 3])
+    assert leaf_node.index == 5
+    assert leaf_node.depth == 2
+    assert leaf_node.value == 3.14
+    assert leaf_node.idx_split_variable == -1
+    assert np.array_equal(leaf_node.idx_data_points, [1, 2, 3])
+    assert leaf_node.get_idx_parent_node() == 2
+    assert leaf_node.get_idx_left_child() == 11
+    assert leaf_node.get_idx_right_child() == 12
+    assert leaf_node.is_split_node() is False
+    assert leaf_node.is_leaf_node() is True


### PR DESCRIPTION
Refactor of the classes BaseNode, SplitNode and LeafNode to avoid using inheritance into just one class Node, so we could use JitClasses of numba in the near future;