### PR TITLE
Fixing issue ThemeError for read the docs

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,3 @@
 nbsphinx>=0.4.2
 pydata-sphinx-theme>=0.6.3
-sphinx>=4
+sphinx==5.3.0


### PR DESCRIPTION
Adding PyMC logo and favicon into the docs/conf.py to avoid issue "sphinx.errors.ThemeError: An error happened in rendering the page api_reference.

Reason: UndefinedError("'logo' is undefined")" for the action 'Read the Docs build';