### PR TITLE
Fixing issue ThemeError for read the docs

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,3 @@
 nbsphinx>=0.4.2
 pydata-sphinx-theme>=0.6.3
-sphinx>=4
+sphinx==5.3.0


### PR DESCRIPTION
Pinning dependency of sphinx to version 5.3.0 to avoid issues on GitHub action ( following good practices from [readthedocs.io](https://docs.readthedocs.io/en/latest/guides/reproducible-builds.html#pinning-dependencies)) to avoid issue: 
```
"sphinx.errors.ThemeError: An error happened in rendering the page api_reference."
```
Examples of building failing in version v6.1.2:
- [19106719](https://readthedocs.org/projects/pymc-bart/builds/19106719/)
- [19079254](https://readthedocs.org/projects/pymc-bart/builds/19079254/)