### PR TITLE
Improvements over Tree implementation

### DIFF
--- a/pymc_bart/tree.py
+++ b/pymc_bart/tree.py
@@ -15,6 +15,7 @@
 import math
 
 from copy import deepcopy
+from functools import lru_cache
 
 from pytensor import config
 import numpy as np
@@ -41,7 +42,6 @@ class Tree:
 
     Parameters
     ----------
-    leaf_node_value : int or float
     idx_data_points : array of integers
     num_observations : integer
     shape : int
@@ -51,7 +51,6 @@ class Tree:
         "tree_structure",
         "idx_leaf_nodes",
         "output",
-        "leaf_node_value",
     )
 
     def __init__(self, leaf_node_value, idx_data_points, num_observations, shape):
@@ -88,7 +87,6 @@ class Tree:
         del a_tree.idx_leaf_nodes
         for k in a_tree.tree_structure.keys():
             current_node = a_tree[k]
-            del current_node.depth
             if current_node.is_leaf_node():
                 del current_node.idx_data_points
         return a_tree
@@ -174,11 +172,10 @@ class Tree:
 
 
 class Node:
-    __slots__ = "index", "depth", "value", "idx_split_variable", "idx_data_points"
+    __slots__ = "index", "value", "idx_split_variable", "idx_data_points"
 
     def __init__(self, index: int, value=-1, idx_data_points=None, idx_split_variable=-1):
         self.index = index
-        self.depth = int(math.floor(math.log(index + 1, 2)))
         self.value = value
         self.idx_data_points = idx_data_points
         self.idx_split_variable = idx_split_variable
@@ -205,3 +202,8 @@ class Node:
 
     def is_leaf_node(self) -> bool:
         return not self.is_split_node()
+
+
+@lru_cache
+def get_depth(index: int) -> int:
+    return int(math.floor(math.log(index + 1, 2)))

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,12 +1,12 @@
 import numpy as np
 
-from pymc_bart.tree import Node
+from pymc_bart.tree import Node, get_depth
 
 
 def test_split_node():
     split_node = Node.new_split_node(index=5, idx_split_variable=2, split_value=3.0)
     assert split_node.index == 5
-    assert split_node.depth == 2
+    assert get_depth(split_node.index) == 2
     assert split_node.value == 3.0
     assert split_node.idx_split_variable == 2
     assert split_node.idx_data_points is None
@@ -20,7 +20,7 @@ def test_split_node():
 def test_leaf_node():
     leaf_node = Node.new_leaf_node(index=5, value=3.14, idx_data_points=[1, 2, 3])
     assert leaf_node.index == 5
-    assert leaf_node.depth == 2
+    assert get_depth(leaf_node.index) == 2
     assert leaf_node.value == 3.14
     assert leaf_node.idx_split_variable == -1
     assert np.array_equal(leaf_node.idx_data_points, [1, 2, 3])


### PR DESCRIPTION
Improvements over Tree implementation:
- Remove variable depth on the Node class to be a method;
- Remove variable leaf_node_value on the Tree class as is not need and was only writing and never read of it;

Tested Mac with chip M1, 8 cores and 16 gb of ram having the next results:

<table class="table-performance">
   <thead>
      <tr class="table-header">
         <th colspan=3>Configuration</th>
         <th colspan=2>version performances</th>
         <th>improvements</th>
      </tr>
   </thead>
   <tbody>
      <tr>
         <td>model name</td>
         <td>tree º</td>
         <td>particle º</td>
         <td>current</td>
         <td>new</td>
         <td>%</td>
      </tr>
      <tr>
         <td rowspan=9><a href="https://github.com/Grupo-de-modelado-probabilista/BART/blob/master/optimization/case_studies/bart_case_biking.py"> biking </a></td>
         <td rowspan=3>50</td>
         <td>20</td>
         <td>98 sec</td>
         <td>85 sec</td>
         <td>13,27%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>158 sec</td>
         <td>123 sec</td>
         <td>22,15%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>201 sec</td>
         <td>160 sec</td>
         <td>20,40%</td>
      </tr>
      <tr>
         <td rowspan=3>100</td>
         <td>20</td>
         <td>146 sec</td>
         <td>115 sec</td>
         <td>21,23%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>240 sec</td>
         <td>207 sec</td>
         <td>13,75%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>332 sec</td>
         <td>262 sec</td>
         <td>21,08%</td>
      </tr>
      <tr>
         <td rowspan=3>200</td>
         <td>20</td>
         <td>232 sec</td>
         <td>212 sec</td>
         <td>8,62%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>487 sec</td>
         <td>338 sec</td>
         <td>30,60%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>620 sec</td>
         <td>519 sec</td>
         <td>16,29%</td>
      </tr>
      <tr>
         <td rowspan=9><a href="https://github.com/Grupo-de-modelado-probabilista/BART/blob/master/optimization/case_studies/bart_case_coal.py">coal</a></td>
         <td rowspan=3>50</td>
         <td>20</td>
         <td>100 sec</td>
         <td>67 sec</td>
         <td>33,00%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>134 sec</td>
         <td>92 sec</td>
         <td>31,34%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>177 sec</td>
         <td>124 sec</td>
         <td>29,94%</td>
      </tr>
      <tr>
         <td rowspan=3>100</td>
         <td>20</td>
         <td>109 sec</td>
         <td>97 sec</td>
         <td>11,01%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>180 sec</td>
         <td>154 sec</td>
         <td>14,44%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>247 sec</td>
         <td>209 sec</td>
         <td>15,38%</td>
      </tr>
      <tr>
         <td rowspan=3>200</td>
         <td>20</td>
         <td>183 sec</td>
         <td>159 sec</td>
         <td>13,11%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>313 sec</td>
         <td>264 sec</td>
         <td>15,65%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>451 sec</td>
         <td>381 sec</td>
         <td>15,52%</td>
      </tr>
      <tr>
         <td rowspan=9><a href="https://github.com/Grupo-de-modelado-probabilista/BART/blob/master/optimization/case_studies/bart_case_friedman.py">friedman</a></td>
         <td rowspan=3>50</td>
         <td>20</td>
         <td>115 sec</td>
         <td>78 sec</td>
         <td>32,17%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>169 sec</td>
         <td>120 sec</td>
         <td>28,99%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>253 sec</td>
         <td>171 sec</td>
         <td>32,41%</td>
      </tr>
      <tr>
         <td rowspan=3>100</td>
         <td>20</td>
         <td>166 sec</td>
         <td>118 sec</td>
         <td>28,92%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>277 sec</td>
         <td>216 sec</td>
         <td>22,02%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>376 sec</td>
         <td>304 sec</td>
         <td>19,15%</td>
      </tr>
      <tr>
         <td rowspan=3>200</td>
         <td>20</td>
         <td>289 sec</td>
         <td>199 sec</td>
         <td>31,14%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>527 sec</td>
         <td>380 sec</td>
         <td>27,89%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>716 sec</td>
         <td>556 sec</td>
         <td>22,35%</td>
      </tr>
      <tr>
         <td rowspan=9><a href="https://github.com/Grupo-de-modelado-probabilista/BART/blob/master/optimization/case_studies/bart_case_space_influenza.py">space_influenza</a></td>
         <td rowspan=3>50</td>
         <td>20</td>
         <td>94 sec</td>
         <td>79 sec</td>
         <td>15,96%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>143 sec</td>
         <td>115 sec</td>
         <td>19,58%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>195 sec</td>
         <td>158 sec</td>
         <td>18,97%</td>
      </tr>
      <tr>
         <td rowspan=3>100</td>
         <td>20</td>
         <td>144 sec</td>
         <td>109 sec</td>
         <td>24,31%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>234 sec</td>
         <td>198 sec</td>
         <td>15,38%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>328 sec</td>
         <td>262 sec</td>
         <td>20,12%</td>
      </tr>
      <tr>
         <td rowspan=3>200</td>
         <td>20</td>
         <td>284 sec</td>
         <td>178 sec</td>
         <td>37,32%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>500 sec</td>
         <td>310 sec</td>
         <td>38,00%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>633 sec</td>
         <td>444 sec</td>
         <td>29,86%</td>
      </tr>
   </tbody>
</table>