### PR TITLE
fix import error from pymc 5.0.2

### DIFF
--- a/pymc_bart/pgbart.py
+++ b/pymc_bart/pgbart.py
@@ -24,7 +24,8 @@ from pytensor import config
 from pytensor.tensor.var import Variable
 
 from pymc.model import modelcontext
-from pymc.step_methods.arraystep import ArrayStepShared, Competence
+from pymc.step_methods.arraystep import ArrayStepShared
+from pymc.step_methods.compound import Competence
 from pymc.pytensorf import inputvars, join_nonshared_inputs, make_shared_replacements
 
 from pymc_bart.bart import BARTRV


### PR DESCRIPTION
Closes https://github.com/pymc-devs/pymc-bart/issues/42

This PR just fixes the import. Do you want me to add the `if else` statement for the `pymc` version for backwards compatibility? 