### PR TITLE
Avoid Deepcopy on Tree and ParticleTree

### DIFF
--- a/pymc_bart/pgbart.py
+++ b/pymc_bart/pgbart.py
@@ -14,7 +14,6 @@
 
 import logging
 
-from copy import deepcopy
 from numba import njit
 
 import numpy as np
@@ -107,7 +106,7 @@ class PGBART(ArrayStepShared):
             config.floatX
         )
         self.sum_trees_noi = self.sum_trees - (init_mean / self.m)
-        self.a_tree = Tree(
+        self.a_tree = Tree.new_tree(
             leaf_node_value=init_mean / self.m,
             idx_data_points=np.arange(self.num_observations, dtype="int32"),
             num_observations=self.num_observations,
@@ -136,9 +135,7 @@ class PGBART(ArrayStepShared):
 
         shared = make_shared_replacements(initial_values, vars, model)
         self.likelihood_logp = logp(initial_values, [model.datalogp], vars, shared)
-        self.all_particles = []
-        for _ in range(self.m):
-            self.all_particles.append(ParticleTree(self.a_tree))
+        self.all_particles = list(ParticleTree(self.a_tree) for _ in range(self.m))
         self.all_trees = np.array([p.tree for p in self.all_particles])
         super().__init__(vars, shared)
 
@@ -239,7 +236,7 @@ class PGBART(ArrayStepShared):
         new_particles = []
         for idx in new_indices:
             if idx in seen:
-                new_particles.append(deepcopy(particles[idx]))
+                new_particles.append(particles[idx].copy())
             else:
                 new_particles.append(particles[idx])
                 seen.append(idx)
@@ -274,7 +271,7 @@ class PGBART(ArrayStepShared):
     def init_particles(self, tree_id: int) -> np.ndarray:
         """Initialize particles."""
         p0 = self.all_particles[tree_id]
-        p1 = deepcopy(p0)
+        p1 = p0.copy()
         p1.sample_leafs(
             self.sum_trees,
             self.m,
@@ -328,11 +325,14 @@ class ParticleTree:
     __slots__ = "tree", "expansion_nodes", "log_weight", "old_likelihood_logp", "kfactor"
 
     def __init__(self, tree):
-        self.tree = tree.copy()  # keeps the tree that we care at the moment
-        self.expansion_nodes = [0]
-        self.log_weight = 0
-        self.old_likelihood_logp = 0
-        self.kfactor = 0.75
+        self.tree, self.expansion_nodes, self.log_weight, self.old_likelihood_logp, self.kfactor = \
+            tree.copy(), [0], 0, 0, 0.75
+
+    def copy(self):
+        p = ParticleTree(self.tree)
+        p.expansion_nodes, p.log_weight, p.old_likelihood_logp, p.kfactor = \
+            self.expansion_nodes.copy(), self.log_weight, self.old_likelihood_logp, self.kfactor
+        return p
 
     def sample_tree(
         self,

--- a/pymc_bart/tree.py
+++ b/pymc_bart/tree.py
@@ -42,9 +42,9 @@ class Tree:
 
     Parameters
     ----------
-    idx_data_points : array of integers
-    num_observations : integer
-    shape : int
+    tree_structure : Dictionary of nodes
+    idx_leaf_nodes :  List with the index of the leaf nodes of the tree.
+    output : Array of shape number of observations, shape
     """
 
     __slots__ = (
@@ -53,12 +53,18 @@ class Tree:
         "output",
     )
 
-    def __init__(self, leaf_node_value, idx_data_points, num_observations, shape):
-        self.tree_structure = {
-            0: Node.new_leaf_node(0, value=leaf_node_value, idx_data_points=idx_data_points)
-        }
-        self.idx_leaf_nodes = [0]
-        self.output = np.zeros((num_observations, shape)).astype(config.floatX).squeeze()
+    def __init__(self, tree_structure, idx_leaf_nodes, output):
+        self.tree_structure, self.idx_leaf_nodes, self.output = tree_structure, idx_leaf_nodes, output
+
+    @classmethod
+    def new_tree(cls, leaf_node_value, idx_data_points, num_observations, shape):
+        return cls(
+            tree_structure={
+                0: Node.new_leaf_node(0, value=leaf_node_value, idx_data_points=idx_data_points)
+            },
+            idx_leaf_nodes=[0],
+            output=np.zeros((num_observations, shape)).astype(config.floatX).squeeze(),
+        )
 
     def __getitem__(self, index):
         return self.get_node(index)
@@ -67,7 +73,10 @@ class Tree:
         self.set_node(index, node)
 
     def copy(self):
-        return deepcopy(self)
+        tree = {k: Node(v.index, v.value, v.idx_data_points, v.idx_split_variable)
+                for k, v in
+                self.tree_structure.items()}
+        return Tree(tree, self.idx_leaf_nodes.copy(), deepcopy(self.output))
 
     def get_node(self, index) -> "Node":
         return self.tree_structure[index]
@@ -82,14 +91,10 @@ class Tree:
         del self.tree_structure[index]
 
     def trim(self):
-        a_tree = self.copy()
-        del a_tree.output
-        del a_tree.idx_leaf_nodes
-        for k in a_tree.tree_structure.keys():
-            current_node = a_tree[k]
-            if current_node.is_leaf_node():
-                del current_node.idx_data_points
-        return a_tree
+        tree = {k: Node(v.index, v.value, None, v.idx_split_variable)
+                for k, v in
+                self.tree_structure.items()}
+        return Tree(tree, None, None)
 
     def get_split_variables(self):
         return [
@@ -175,10 +180,8 @@ class Node:
     __slots__ = "index", "value", "idx_split_variable", "idx_data_points"
 
     def __init__(self, index: int, value=-1, idx_data_points=None, idx_split_variable=-1):
-        self.index = index
-        self.value = value
-        self.idx_data_points = idx_data_points
-        self.idx_split_variable = idx_split_variable
+        self.index, self.value, self.idx_data_points, self.idx_split_variable = \
+            index, value, idx_data_points, idx_split_variable
 
     @classmethod
     def new_leaf_node(cls, index: int, value, idx_data_points) -> "Node":


### PR DESCRIPTION
To avoid deepcopy we have to change some constructors and implement method copy, here is the list of all the changes:
- Implement a constructor of Tree with all the attributes(tree_structure, idx_leaf_nodes and output);
- Create the class method new_tree with the previous behavior of the constructor;
- Change the implementation of copy on Tree, avoiding deepcopying all and just deepcopying the output;
- Improve method trim(), previously we copy all and then we delete the attributes that we do not need, now we just create the tree copying the attributes that we care; 
- Instead of creating an empty list and append each particle we create an comprehensive list; We implement the method copy on ParticleTree, instead of deepcopying;

Tested Mac with chip M1, 8 cores and 16 gb of ram having the next results:

<table class="table-performance">
   <thead>
      <tr class="table-header">
         <th colspan=3>Configuration</th>
         <th colspan=2>version performances</th>
         <th>improvements</th>
      </tr>
   </thead>
   <tbody>
      <tr>
         <td>model name</td>
         <td>tree º</td>
         <td>particle º</td>
         <td>current</td>
         <td>new</td>
         <td>%</td>
      </tr>
      <tr>
         <td rowspan=9><a href="https://github.com/Grupo-de-modelado-probabilista/BART/blob/master/optimization/case_studies/bart_case_biking.py"> biking </a></td>
         <td rowspan=3>50</td>
         <td>20</td>
         <td>85 sec</td>
         <td>74 sec</td>
         <td>12,94%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>123 sec</td>
         <td>99 sec</td>
         <td>19,51%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>160 sec</td>
         <td>128 sec</td>
         <td>20,00%</td>
      </tr>
      <tr>
         <td rowspan=3>100</td>
         <td>20</td>
         <td>115 sec</td>
         <td>103 sec</td>
         <td>10,43%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>207 sec</td>
         <td>154 sec</td>
         <td>25,60%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>262 sec</td>
         <td>209 sec</td>
         <td>20,23%</td>
      </tr>
      <tr>
         <td rowspan=3>200</td>
         <td>20</td>
         <td>212 sec</td>
         <td>164 sec</td>
         <td>22,64%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>338 sec</td>
         <td>267 sec</td>
         <td>21,01%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>519 sec</td>
         <td>378 sec</td>
         <td>27,17%</td>
      </tr>
      <tr>
         <td rowspan=9><a href="https://github.com/Grupo-de-modelado-probabilista/BART/blob/master/optimization/case_studies/bart_case_coal.py">coal</a></td>
         <td rowspan=3>50</td>
         <td>20</td>
         <td>67 sec</td>
         <td>57 sec</td>
         <td>14,93%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>92 sec</td>
         <td>83 sec</td>
         <td>9,78%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>124 sec</td>
         <td>104 sec</td>
         <td>16,13%</td>
      </tr>
      <tr>
         <td rowspan=3>100</td>
         <td>20</td>
         <td>97 sec</td>
         <td>85 sec</td>
         <td>12,37%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>154 sec</td>
         <td>135 sec</td>
         <td>12,34%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>209 sec</td>
         <td>181 sec</td>
         <td>13,40%</td>
      </tr>
      <tr>
         <td rowspan=3>200</td>
         <td>20</td>
         <td>159 sec</td>
         <td>138 sec</td>
         <td>13,21%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>264 sec</td>
         <td>229 sec</td>
         <td>13,26%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>381 sec</td>
         <td>319 sec</td>
         <td>16,27%</td>
      </tr>
      <tr>
         <td rowspan=9><a href="https://github.com/Grupo-de-modelado-probabilista/BART/blob/master/optimization/case_studies/bart_case_friedman.py">friedman</a></td>
         <td rowspan=3>50</td>
         <td>20</td>
         <td>78 sec</td>
         <td>65 sec</td>
         <td>16,67%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>120 sec</td>
         <td>91 sec</td>
         <td>24,17%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>171 sec</td>
         <td>115 sec</td>
         <td>32,75%</td>
      </tr>
      <tr>
         <td rowspan=3>100</td>
         <td>20</td>
         <td>118 sec</td>
         <td>93 sec</td>
         <td>21,19%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>216 sec</td>
         <td>144 sec</td>
         <td>33,33%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>304 sec</td>
         <td>200 sec</td>
         <td>34,21%</td>
      </tr>
      <tr>
         <td rowspan=3>200</td>
         <td>20</td>
         <td>199 sec</td>
         <td>150 sec</td>
         <td>24,62%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>380 sec</td>
         <td>246 sec</td>
         <td>35,26%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>556 sec</td>
         <td>354 sec</td>
         <td>36,33%</td>
      </tr>
      <tr>
         <td rowspan=9><a href="https://github.com/Grupo-de-modelado-probabilista/BART/blob/master/optimization/case_studies/bart_case_space_influenza.py">space_influenza</a></td>
         <td rowspan=3>50</td>
         <td>20</td>
         <td>79 sec</td>
         <td>66 sec</td>
         <td>16,46%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>115 sec</td>
         <td>95 sec</td>
         <td>17,39%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>158 sec</td>
         <td>125 sec</td>
         <td>20,89%</td>
      </tr>
      <tr>
         <td rowspan=3>100</td>
         <td>20</td>
         <td>109 sec</td>
         <td>101 sec</td>
         <td>7,34%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>198 sec</td>
         <td>153 sec</td>
         <td>22,73%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>262 sec</td>
         <td>207 sec</td>
         <td>20,99%</td>
      </tr>
      <tr>
         <td rowspan=3>200</td>
         <td>20</td>
         <td>178 sec</td>
         <td>158 sec</td>
         <td>11,24%</td>
      </tr>
      <tr>
         <td>40</td>
         <td>310 sec</td>
         <td>271 sec</td>
         <td>12,58%</td>
      </tr>
      <tr>
         <td>60</td>
         <td>444 sec</td>
         <td>381 sec</td>
         <td>14,19%</td>
      </tr>
   </tbody>
</table>