### PR TITLE
Allow training separate tree structures if training multiple trees

### DIFF
--- a/pymc_bart/bart.py
+++ b/pymc_bart/bart.py
@@ -40,7 +40,7 @@ class BARTRV(RandomVariable):
     ndims_params: List[int] = [2, 1, 0, 0, 0, 1]
     dtype: str = "floatX"
     _print_name: Tuple[str, str] = ("BART", "\\operatorname{BART}")
-    all_trees = List[List[Tree]]
+    all_trees = List[List[List[Tree]]]
 
     def _supp_shape_from_params(self, dist_params, rep_param_idx=1, param_shapes=None):
         return dist_params[0].shape[:1]
@@ -96,6 +96,15 @@ class BART(Distribution):
         List of SplitRule objects, one per column in input data.
         Allows using different split rules for different columns. Default is ContinuousSplitRule.
         Other options are OneHotSplitRule and SubsetSplitRule, both meant for categorical variables.
+    shape: : Optional[Tuple], default None
+        Specify the output shape. If shape is different from (len(X)) (the default), train a
+        separate tree for each value in other dimensions.
+    separate_trees : Optional[bool], default False
+        When training multiple trees (by setting a shape parameter), the default behavior is to
+        learn a joint tree structure and only have different leaf values for each.
+        This flag forces a fully separate tree structure to be trained instead.
+        This is unnecessary in many cases and is considerably slower, multiplying
+        run-time roughly by number of dimensions.
 
     Notes
     -----
@@ -115,6 +124,7 @@ class BART(Distribution):
         response: str = "constant",
         split_prior: Optional[List[float]] = None,
         split_rules: Optional[SplitRule] = None,
+        separate_trees: Optional[bool] = False,
         **kwargs,
     ):
         manager = Manager()
@@ -141,6 +151,7 @@ class BART(Distribution):
                 beta=beta,
                 split_prior=split_prior,
                 split_rules=split_rules,
+                separate_trees=separate_trees,
             ),
         )()
 

--- a/pymc_bart/tree.py
+++ b/pymc_bart/tree.py
@@ -147,7 +147,7 @@ class Tree:
                 )
             },
             idx_leaf_nodes=[0],
-            output=np.zeros((num_observations, shape)).astype(config.floatX).squeeze(),
+            output=np.zeros((num_observations, shape)).astype(config.floatX),
             split_rules=split_rules,
         )
 
@@ -226,7 +226,7 @@ class Tree:
         if self.idx_leaf_nodes is not None:
             for node_index in self.idx_leaf_nodes:
                 leaf_node = self.get_node(node_index)
-                output[leaf_node.idx_data_points] = leaf_node.value.squeeze()
+                output[leaf_node.idx_data_points] = leaf_node.value
         return output.T
 
     def predict(


### PR DESCRIPTION
This adds a separate_trees flag that allows training non-shared tree structures if training multiple trees.
This is considerably slower (roughly multiplies the time taken by the number of trees being trained) but can result in drastic decreases in variability of results.

Attached is an example of results of BART with shared structure (joint), BART with separate trees and GLM all trained on SALK polling data. As you can see, in this case, the separation really matters a lot, so hopefully this serves as a motivating example:
![image](https://github.com/pymc-devs/pymc-bart/assets/5527789/e6d9daaa-6f3e-4491-8f3f-dfc18f21c962)


