### PR TITLE
Fix ICE plot when there is a discrete variable

### DIFF
--- a/pymc_bart/utils.py
+++ b/pymc_bart/utils.py
@@ -289,7 +289,7 @@ def plot_ice(
                 p_di = func(p_d[:, :, s_i])
             if var in var_discrete:
                 axes[count].plot(new_x, p_di.mean(0), "o", color=color_mean)
-                axes[count].plot(new_x, p_di, ".", color=color, alpha=alpha)
+                axes[count].plot(new_x, p_di.T, ".", color=color, alpha=alpha)
             else:
                 if smooth:
                     x_data, y_data = _smooth_mean(new_x, p_di, "ice", smooth_kwargs)

--- a/tests/test_bart.py
+++ b/tests/test_bart.py
@@ -160,6 +160,7 @@ class TestUtils:
             {"instances": 2},
             {"var_idx": [0], "smooth": False, "color": "k"},
             {"grid": (1, 2), "sharey": "none", "alpha": 1},
+            {"var_discrete": [0]}
         ],
     )
     def test_ice(self, kwargs):
@@ -177,6 +178,7 @@ class TestUtils:
             },
             {"var_idx": [0], "smooth": False, "color": "k"},
             {"grid": (1, 2), "sharey": "none", "alpha": 1},
+            {"var_discrete": [0]}
         ],
     )
     def test_pdp(self, kwargs):


### PR DESCRIPTION
Closes https://github.com/pymc-devs/pymc-bart/issues/106

- [x] Fix issue.
- [x] Add tests.

This change produces the expected plot:

```python
pmb.plot_ice(μ, X=X, Y=Y, grid=(2, 2), func=np.exp, var_discrete=[0])
```

![image](https://github.com/pymc-devs/pymc-bart/assets/22996444/4c25770b-b86d-4e8e-9b4b-e18b02047bc5)

