### PR TITLE
Resolve deprecation warning for `pytensor`'s `Variable`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     name: Set up Python ${{ matrix.python-version }}
     steps:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 python:
    install:

--- a/pymc_bart/pgbart.py
+++ b/pymc_bart/pgbart.py
@@ -23,7 +23,7 @@ from pymc.step_methods.arraystep import ArrayStepShared
 from pymc.step_methods.compound import Competence
 from pytensor import config
 from pytensor import function as pytensor_function
-from pytensor.tensor.var import Variable
+from pytensor.tensor.variable import Variable
 
 from pymc_bart.bart import BARTRV
 from pymc_bart.split_rules import ContinuousSplitRule

--- a/pymc_bart/utils.py
+++ b/pymc_bart/utils.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 import pytensor.tensor as pt
-from pytensor.tensor.var import Variable
+from pytensor.tensor.variable import Variable
 from scipy.interpolate import griddata
 from scipy.signal import savgol_filter
 from scipy.stats import norm, pearsonr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pymc>=5.0.0
-arviz
+pymc>=5.13.1
+arviz>=0.18.0
 numba
 matplotlib
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pymc>=5.13.1
-arviz>=0.18.0
+pymc==5.13.1
+arviz==0.18.0
 numba
 matplotlib
 numpy


### PR DESCRIPTION
Pytensor has renamed `pytensor.tensor.var` to `pytensor.tensor.variable`.
Imports in pymc_bart rely on the legacy `.var` call, which within pytensor resolves by throwing a warning and importing the renamed variable sub-module. [Pytensor commit ref](https://github.com/pymc-devs/pytensor/commit/6d3c75683e51ba44242d0860c5f6b56eb6b23205)

This PR simply updates pymc_bart to call the modern `.variable` directly