### PR TITLE
pin pymc==5.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: mypy
         args: [--ignore-missing-imports]
         files: ^pymc_bart/
-        additional_dependencies: [numpy<1.25.0, pandas-stubs==1.5.3.230304]
+        additional_dependencies: [numpy, pandas-stubs]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pymc>=5.13.1
+pymc==5.14.0
 arviz>=0.18.0
 numba
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pymc==5.13.1
-arviz==0.18.0
+pymc=>5.13.1
+arviz=>0.18.0
 numba
 matplotlib
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pymc=>5.13.1
-arviz=>0.18.0
+pymc>=5.13.1
+arviz>=0.18.0
 numba
 matplotlib
 numpy


### PR DESCRIPTION
~~As we have new releases (https://github.com/pymc-devs/pymc/releases) regularly, I suggest we unpin the exact versions of PyMC and Arviz :)~~

I changed the scope and just pinned the latest version.

I also removed the pre-commit restrictions as they are not necessary 