### PR TITLE
Enable passing `Y` as a `SharedVariable` to `pm.Bart`

### DIFF
--- a/pymc_bart/bart.py
+++ b/pymc_bart/bart.py
@@ -25,6 +25,7 @@ from pandas import DataFrame, Series
 from pymc.distributions.distribution import Distribution, _support_point
 from pymc.logprob.abstract import _logprob
 from pytensor.tensor.random.op import RandomVariable
+from pytensor.tensor.sharedvar import TensorSharedVariable
 
 from .split_rules import SplitRule
 from .tree import Tree
@@ -53,11 +54,16 @@ class BARTRV(RandomVariable):
         if not size:
             size = None
 
+        if isinstance(cls.Y, TensorSharedVariable):
+            Y = cls.Y.eval()
+        else:
+            Y = cls.Y
+
         if not cls.all_trees:
             if size is not None:
-                return np.full((size[0], cls.Y.shape[0]), cls.Y.mean())
+                return np.full((size[0], Y.shape[0]), Y.mean())
             else:
-                return np.full(cls.Y.shape[0], cls.Y.mean())
+                return np.full(Y.shape[0], Y.mean())
         else:
             if size is not None:
                 shape = size[0]


### PR DESCRIPTION
Ready for review 🍾 

This PR solves the following issue by adding a check in `rng_fn` of whether `Y` is a `SharedVariable`:
```python
# Generate synthetic data
n_samples = 1000
n_features = 10

# Generate feature matrix X with some correlations
X = rng.normal(0, 1, size=(n_samples, n_features))
# Add some correlation between features
X[:, 1] = 0.6 * X[:, 0] + 0.4 * rng.normal(0, 1, n_samples)
X[:, 2] = -0.3 * X[:, 0] + 0.7 * rng.normal(0, 1, n_samples)

# Generate true relationship (non-linear with interactions)
true_y = (
    np.sin(X[:, 0])
    + 0.5 * X[:, 1] ** 2
    + 0.2 * X[:, 0] * X[:, 1]
    + 0.3 * np.exp(X[:, 2])
    + 0.1 * X[:, 3]
)

# Add noise
noise = rng.normal(0, 0.2, n_samples)
y = true_y + noise

with pm.Model() as bart_model:
    X_data = pm.Data("X", X)
    y_data = pm.Data("y", y)

    mu = pmb.BART("mu", X=X_data, Y=y_data, m=50)
    sigma = pm.Exponential("noise_obs", 1)

    _ = pm.Normal(
        "y_obs",
        mu=mu,
        sigma=sigma,
        observed=y_data,
    )

with bart_model:
    idata = pm.sample_prior_predictive()
    idata.extend(pm.sample())
    idata.extend(pm.sample_posterior_predictive(idata))
```
```console
TypeError: expected a sequence of integers or a single integer, got 'Subtensor{i}.0'
Apply node that caused the error: BART_rv{"(m,n),(m),(),(),() -> (m)"}(RNG(<Generator(PCG64) at 0x70ABEF69B140>), [], X, y, 50, 0.95, 2.0)
Toposort index: 0
Inputs types: [RandomGeneratorType, TensorType(int64, shape=(0,)), TensorType(float64, shape=(None, None)), TensorType(float64, shape=(None,)), TensorType(int8, shape=()), TensorType(float64, shape=()), TensorType(float32, shape=())]
Inputs shapes: ['No shapes', (0,), (24413, 11), (24413,), (), (), ()]
Inputs strides: ['No strides', (0,), (8, 195304), (8,), (), (), ()]
Inputs values: [Generator(PCG64) at 0x70ABEF69B140, array([], dtype=int64), 'not shown', 'not shown', array(50, dtype=int8), array(0.95), array(2., dtype=float32)]
Outputs clients: [[output[3](BART_rv{"(m,n),(m),(),(),() -> (m)"}.0)], [output[0](mu), normal_rv{"(),()->()"}(RNG(<Generator(PCG64) at 0x70ABEF69B220>), MakeVector{dtype='int64'}.0, mu, ExpandDims{axis=0}.0)]]
```