### PR TITLE
Patch for case when Y is a TensorVariable

### DIFF
--- a/pymc_bart/bart.py
+++ b/pymc_bart/bart.py
@@ -55,7 +55,7 @@ class BARTRV(RandomVariable):
         if not size:
             size = None
 
-        if isinstance(cls.Y, TensorSharedVariable) or isinstance(cls.Y, TensorVariable):
+        if isinstance(cls.Y, (TensorSharedVariable, TensorVariable)):
             Y = cls.Y.eval()
         else:
             Y = cls.Y

--- a/pymc_bart/bart.py
+++ b/pymc_bart/bart.py
@@ -26,6 +26,7 @@ from pymc.distributions.distribution import Distribution, _support_point
 from pymc.logprob.abstract import _logprob
 from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.sharedvar import TensorSharedVariable
+from pytensor.tensor.variable import TensorVariable
 
 from .split_rules import SplitRule
 from .tree import Tree
@@ -54,7 +55,7 @@ class BARTRV(RandomVariable):
         if not size:
             size = None
 
-        if isinstance(cls.Y, TensorSharedVariable):
+        if isinstance(cls.Y, TensorSharedVariable) or isinstance(cls.Y, TensorVariable):
             Y = cls.Y.eval()
         else:
             Y = cls.Y


### PR DESCRIPTION
#202 enabled passing y as `SharedVariable`, but for some reason, sometimes `Y` is cast to `TensorVariable` somewhere upstream, even though it's declared as a `SharedVariable` in the model.

This PR just makes sure this case is also handled