### PR TITLE
Add support for multiple BART random variables per model.

### DIFF
--- a/pymc_bart/pgbart.py
+++ b/pymc_bart/pgbart.py
@@ -130,6 +130,7 @@ class PGBART(ArrayStepShared):
         model: Optional[Model] = None,
         initial_point: PointType | None = None,
         compile_kwargs: dict | None = None,
+        **kwargs,  # Accept additional kwargs for compound sampling
     ) -> None:
         model = modelcontext(model)
         if initial_point is None:
@@ -143,7 +144,24 @@ class PGBART(ArrayStepShared):
         if vars is None:
             raise ValueError("Unable to find variables to sample")
 
-        value_bart = vars[0]
+        # Filter to only BART variables
+        bart_vars = []
+        for var in vars:
+            rv = model.values_to_rvs.get(var)
+            if rv is not None and isinstance(rv.owner.op, BARTRV):
+                bart_vars.append(var)
+
+        if not bart_vars:
+            raise ValueError("No BART variables found in the provided variables")
+
+        if len(bart_vars) > 1:
+            raise ValueError(
+                "PGBART can only handle one BART variable at a time. "
+                "For multiple BART variables, PyMC will automatically create "
+                "separate PGBART samplers for each variable."
+            )
+
+        value_bart = bart_vars[0]
         self.bart = model.values_to_rvs[value_bart].owner.op
 
         if isinstance(self.bart.X, Variable):
@@ -227,15 +245,15 @@ class PGBART(ArrayStepShared):
 
         self.num_particles = num_particles
         self.indices = list(range(1, num_particles))
-        shared = make_shared_replacements(initial_point, vars, model)
-        self.likelihood_logp = logp(initial_point, [model.datalogp], vars, shared)
+        shared = make_shared_replacements(initial_point, [value_bart], model)
+        self.likelihood_logp = logp(initial_point, [model.datalogp], [value_bart], shared)
         self.all_particles = [
             [ParticleTree(self.a_tree) for _ in range(self.m)] for _ in range(self.trees_shape)
         ]
         self.all_trees = np.array([[p.tree for p in pl] for pl in self.all_particles])
         self.lower = 0
         self.iter = 0
-        super().__init__(vars, shared)
+        super().__init__([value_bart], shared)
 
     def astep(self, _):
         variable_inclusion = np.zeros(self.num_variates, dtype="int")
@@ -346,7 +364,7 @@ class PGBART(ArrayStepShared):
                 new_particles.append(particles[idx].copy())
             else:
                 new_particles.append(particles[idx])
-                seen.append(idx)
+                seen.append(int(idx))
 
         particles[1:] = new_particles
 


### PR DESCRIPTION
This PR adds new functionality to support multiple BART RVs defined within a single `pymc` model, addressing and resolve the limitation discussed in #86.

- added ability to support multiple BART RVs in a single model (each gets its own `pgbart` sampler with combined sampling handled by `pymc`'s compound sampling functionality)
- tests of new functionality

### Example use

This addition allows for some new modeling possibilities. One example is the Bayesian Causal Forests model of [Hahn et al.](https://arxiv.org/abs/1706.09523). This model aims to capture heterogenous treatment effects of a binary treatment $Z$ by separately capturing the prognostic predictiveness of those covariates $X$ and their interactions with $z$ (note that different $X$ may also be modeled by $\mu$ and $\tau$).

$$f(x_i, z_i) = \mu(x_i) + \tau(x_i) \cdot z_i$$

This can be implemented as:

```python
import pymc as pm
import pymc_bart as pmb

with pm.Model() as bcf_model:
    # Prognostic function (baseline outcome) - BART1
    mu = pmb.BART("mu", X=X_prog, Y=y, m=50) 
    
    # Treatment effect function - BART2
    tau = pmb.BART("tau", X=X_trt, Y=y, m=50)
    
    # Combine the two BART functions
    # Mean function: mu + Z * tau
    mean_y = mu + Z * tau
    
    # Observation noise
    sigma = pm.HalfNormal("sigma", sigma=1.0)
    
    # Likelihood
    y_obs = pm.Normal("y_obs", mu=mean_y, sigma=sigma, observed=y)
```

Hope this looks good. I also plan to offer a more detailed demo example for the `pymc-examples` doc repo if desired!