### PR TITLE
Adapt sample to use new progress bar

### DIFF
--- a/pymc_bart/pgbart.py
+++ b/pymc_bart/pgbart.py
@@ -429,9 +429,13 @@ class PGBART(ArrayStepShared):
         return Competence.INCOMPATIBLE
 
     @staticmethod
-    def _make_update_stats_functions():
+    def _progressbar_config(n_chains=1):
+        return [], {}
+
+    @staticmethod
+    def _make_progressbar_update_functions():
         def update_stats(step_stats):
-            return {key: step_stats[key] for key in ("variable_inclusion", "tune")}
+            return {"tune": step_stats.get("tune", False)}
 
         return (update_stats,)
 


### PR DESCRIPTION
The PyMC progress bar has been updated by https://github.com/pymc-devs/pymc/pull/8055

The new progress bar system requires step methods to implement two static methods:

1. `_progressbar_config(n_chains)` - defines columns and initial stat values
2. `_make_progressbar_update_functions()` - extracts displayable stats from step output
