### PR TITLE
fix: replace Manager().list() with plain list to prevent GC crash

### DIFF
--- a/pymc_bart/bart.py
+++ b/pymc_bart/bart.py
@@ -15,7 +15,6 @@
 #   limitations under the License.
 
 import warnings
-from multiprocessing import Manager
 
 import numpy as np
 import numpy.typing as npt
@@ -139,9 +138,12 @@ class BART(Distribution):
                 "Options linear and mix are experimental and still not well tested\n"
                 + "Use with caution."
             )
-        # Create a unique manager list for each BART instance
-        manager = Manager()
-        instance_all_trees = manager.list()
+        # Use a plain list for tree storage. A Manager().list() was used
+        # previously but the Manager is a local variable here, so it gets
+        # garbage-collected after __new__ returns. Once the Manager's server
+        # process dies the ListProxy becomes a dangling reference, causing
+        # TypeError on out-of-sample prediction calls.
+        instance_all_trees = []
 
         X, Y = preprocess_xy(X, Y)
 

--- a/pymc_bart/bart.py
+++ b/pymc_bart/bart.py
@@ -143,7 +143,7 @@ class BART(Distribution):
         # garbage-collected after __new__ returns. Once the Manager's server
         # process dies the ListProxy becomes a dangling reference, causing
         # TypeError on out-of-sample prediction calls.
-        instance_all_trees = []
+        instance_all_trees: list = []
 
         X, Y = preprocess_xy(X, Y)
 


### PR DESCRIPTION
Fixes #265

The `Manager()` in `BART.__new__` is a local variable that gets garbage-collected after the method returns. Once its server process dies, `all_trees` (a `ListProxy`) becomes a dangling reference — any access to it (e.g. during `sample_posterior_predictive` with new data) raises `TypeError: only integer scalar arrays can be converted to a scalar index`.

Since nothing in the sampling step actually needs cross-process shared state (each chain gets its own copy of the step method), a plain `list()` works fine here and avoids the lifetime issue entirely.

— saschabuehrle